### PR TITLE
Chore/conn name to key

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Once the interceptor has been added, datstar.wow handlers can contain a `:datast
           [::start-timer]]}
 ```
 
-With the interceptor enabled, the default behavior of `:datastar.wow/connection` is augmented to support vector or keyword references to existing connections.
+With the interceptor enabled, the default behavior of `:datastar.wow/connection` is augmented to support lookup by the value of `:datastar.wow.deacon/key`:
 
 ``` clojure
 (defn jump
@@ -123,13 +123,22 @@ With the interceptor enabled, the default behavior of `:datastar.wow/connection`
   [_]
   {::d*/connection ::counter
    :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
+
+(defn jump
+  "Use a composite key of your own design"
+  [_]
+  {::d*/connection [::counter 1]
+   :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
    
+
 (defn jump
   "Use an explicit connection fetched from the connection store (stored on the request here)"
   [{:keys [store]}]
   {::d*/connection (d*conn/connection store [::d*conn/id ::counter])
    :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
 ```
+
+The `:datastar.wow.deacon/key` can contain any value that would be appropriate as a key in a Clojure map
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Adds declarative connection management to a [datastar.wow](https://github.com/br
     :get (let [{:keys [running]} @*state]
            {:body (app running)})
     :delete {::d*/fx [[::d*/patch-signals (reset! *state {:running false :counter 0})]]}
-    :put    {::d*conn/name ::counter ;;; unique connection name signals deacon to store
+    :put    {::d*conn/key ::counter ;;; unique connection key signals deacon to store
              ::d*/with-open-sse? false
              ::d*/fx [[::subscribe ::index]
                       [::start-timer]]}))
@@ -100,10 +100,10 @@ Use `datastar.wow.deacon/update-nexus` to create a function used in `:datastar.w
 
 See [datastar.wow docs](https://github.com/brianium/datastar.wow?tab=readme-ov-file#extending) on extending via `:datastar.wow/update-nexus`.
 
-Once the interceptor has been added, datstar.wow handlers can contain a `:datastar.wow.deacon/name` key in the response indicating the connection should be stored:
+Once the interceptor has been added, datstar.wow handlers can contain a `:datastar.wow.deacon/key` key in the response indicating the connection should be stored:
 
 ``` clojure
-{::d*conn/name ::counter   ;;; unique connection name signals deacon to store
+{::d*conn/key ::counter   ;;; unique connection key signals deacon to store
  ::d*/with-open-sse? false ;;; ::d*/with-open-sse? 
  ::d*/fx [[::subscribe ::index]
           [::start-timer]]}
@@ -135,14 +135,14 @@ With the interceptor enabled, the default behavior of `:datastar.wow/connection`
 
 The second argument to `datastar.wow.deacon/update-nexus` is an options map that can be used to customize behavior.
 
-| key         | description                                                                                                                                                      |
-| ------------| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:id-fn`    | A function that is given the Nexus context and is expected to return a unique id for the session. IDs are used to scope connection names to a particular context |
-| `:on-purge` | A function that is given the Nexus context and is called when a connection is purged in response to a `:datastar.wow/sse-closed` effect                          |
+| key         | description                                                                                                                                                     |
+| ------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:id-fn`    | A function that is given the Nexus context and is expected to return a unique id for the session. IDs are used to scope connection keys to a particular context |
+| `:on-purge` | A function that is given the Nexus context and is called when a connection is purged in response to a `:datastar.wow/sse-closed` effect                         |
 
 ### Note on ids and `:id-fn`
 
-Connection keys are always scoped to a unique session ID. This id defaults to `:datastar.wow.deacon/id`. However, it is useful to be able to store a connection name per session/user.
+Connection keys are always scoped to a unique session ID. This id defaults to `:datastar.wow.deacon/id`. However, it is useful to be able to store a connection key per session/user.
 The `:id-fn` is the way to support this. The Nexus context contains useful information (like the request) for constructing such a key.
 
 ``` clojure
@@ -151,7 +151,7 @@ The `:id-fn` is the way to support this. The Nexus context contains useful infor
 (def store (d*conn/store {:type :atom}))
 
 (defn user-id
-  "scope connection names to individual users"
+  "scope connection keys to individual users"
   [{{:keys [request]} :system}]
   (:user-id request))
 

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
           slipset/deps-deploy {:mvn/version "0.2.2"}}
          :ns-default slim.lib
          :exec-args {:lib         com.github.brianium/datastar.wow.deacon
-                     :version     "1.1.0"
+                     :version     "1.2.0"
                      :url         "https://github.com/brianium/datastar.wow.deacon"
                      :description "Adds declarative connection management to datastar.wow applications"
                      :developer   "Brian Scaturro"}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
                       metosin/malli                    {:mvn/version "0.19.1"}
                       metosin/reitit                   {:mvn/version "0.9.1"}
                       ring/ring-mock                   {:mvn/version "0.6.2"}}}
-  :test {:extra-paths ["test/src"]
+  :test {:extra-paths ["test"]
          :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "cognitect.test-runner"]
          :exec-fn     cognitect.test-runner.api/test}

--- a/dev/src/demo/app.clj
+++ b/dev/src/demo/app.clj
@@ -141,7 +141,7 @@
     :get (let [{:keys [running]} @*state]
            {:body (app running)})
     :delete {:🚀 [[::d*/patch-signals (reset! *state {:running false :counter 0})]]}
-    :put {::d*conn/name ::counter
+    :put {::d*conn/key [::counter 1]
           ::d*/with-open-sse? false
           :🚀 [[::subscribe ::index]
                [::start-timer]]}))
@@ -149,7 +149,7 @@
 (defn jump
   "Adds a whopping 10 to the counter state - using the same connection established via index"
   [_]
-  {::d*/connection [::d*conn/id ::counter]
+  {::d*/connection [::counter 1]
    :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
 
 (defn subscribe

--- a/src/datastar/wow/deacon/interceptors.clj
+++ b/src/datastar/wow/deacon/interceptors.clj
@@ -20,7 +20,7 @@
      (let [{:keys [sse]} system
            store? (not (:datastar.wow/with-open-sse? dispatch-data))
            id     (id-fn ctx)
-           cname  (get-in dispatch-data [:datastar.wow/response :datastar.wow.deacon/name])
+           cname  (get-in dispatch-data [:datastar.wow/response :datastar.wow.deacon/key])
            sse    (cond
                     (keyword? sse) (resolve-conn store [id sse] ctx)
                     (vector? sse)  (resolve-conn store sse ctx)
@@ -35,7 +35,7 @@
    (fn [{:keys [effect system dispatch-data] :as ctx}]
      (let [{:keys [request]} system]
        (when (and effect (= :datastar.wow/sse-closed (first effect)))
-         (when-some [cname (get-in dispatch-data [:datastar.wow/response :datastar.wow.deacon/name])]
+         (when-some [cname (get-in dispatch-data [:datastar.wow/response :datastar.wow.deacon/key])]
            (on-purge ctx)
            (impl/purge! store [(id-fn request) cname]))))
      ctx)})

--- a/test/datastar/wow/deacon_test.clj
+++ b/test/datastar/wow/deacon_test.clj
@@ -76,7 +76,7 @@
    (let [update-nexus (d*conn/update-nexus store opts)
          sse      (atom ::test-conn)
          request  {:session-id ::test-id}
-         response {::d*conn/name ::test-name}
+         response {::d*conn/key ::test-name}
          dispatch-data
          {:datastar.wow/response response
           :datastar.wow/request  request


### PR DESCRIPTION
- Renames `:datastar.wow.deacon/name` to `:datastar.wow.deacon/key`
- `:datastar.wow.deacon/key` and `:datastar.wow/connection` support any key type that would also be valid to a Clojure map.