### PR TITLE
Use `:datastar.wow.deacon/key` for both reading and writing connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Change Log
+
+## [1.3.0] - 2025-09-18
+
+1.3.0 will only work with datastar.wow version [1.0.0-RC1-wow-2](https://clojars.org/com.github.brianium/datastar.wow) and higher.
+
+### Changed
+
+The `:datastar.wow/connection` key is no longer used. `:datastar.wow.deacon/key` is used for writing AND reading connections.
+
+Previously:
+
+```clojure
+(defn handler-1 [_]
+  {::d*conn/key ::counter
+   ::d*/with-open-sse? false
+   ::d*/fx [[::subscribe ::index]
+            [::start-timer]]})
+			
+(defn handler-2 [_]
+  {::d*/connection ::counter})
+```
+
+Now:
+
+```clojure
+(defn handler-1 [_]
+  {::d*conn/key ::counter
+   ::d*/with-open-sse? false
+   ::d*/fx [[::subscribe ::index]
+            [::start-timer]]})
+			
+(defn handler-2 [_]
+  {::d*conn/key ::counter})
+```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Adds declarative connection management to a [datastar.wow](https://github.com/br
 - [Options](#options)
 - [Extending](#extending)
 - [Demo](#demo)
+- [Change Log](CHANGELOG.md)
 
 ## Quick Example
 
@@ -49,7 +50,6 @@ Adds declarative connection management to a [datastar.wow](https://github.com/br
   {::d*/connection ::counter ;;; specify the connection to use
    :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
 ```
-
 ## Installation
 
 `datastar.wow.deacon` is a companion to [datastar.wow](https://github.com/brianium/datastar.wow) and both must be installed in order to enjoy the power.
@@ -104,37 +104,20 @@ Once the interceptor has been added, datstar.wow handlers can contain a `:datast
 
 ``` clojure
 {::d*conn/key ::counter   ;;; unique connection key signals deacon to store
- ::d*/with-open-sse? false ;;; ::d*/with-open-sse? 
+ ::d*/with-open-sse? false
  ::d*/fx [[::subscribe ::index]
           [::start-timer]]}
 ```
 
-With the interceptor enabled, the default behavior of `:datastar.wow/connection` is augmented to support lookup by the value of `:datastar.wow.deacon/key`:
+The key can be any type that would be a valid key in a Clojure map.
+
+Any handler using the same key will re-use the stored connection.
 
 ``` clojure
 (defn jump
   "Reference an explicit connection scoped by the results of :id-fn"
   [_]
-  {::d*/connection [::d*conn/id ::counter]
-   :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
-   
-(defn jump
-  "Use a keyword that expands to a vector that uses the results of :id-fn"
-  [_]
-  {::d*/connection ::counter
-   :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
-
-(defn jump
-  "Use a composite key of your own design"
-  [_]
-  {::d*/connection [::counter 1]
-   :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
-   
-
-(defn jump
-  "Use an explicit connection fetched from the connection store (stored on the request here)"
-  [{:keys [store]}]
-  {::d*/connection (d*conn/connection store [::d*conn/id ::counter])
+  {::d*conn/key ::counter
    :🚀 [[::d*/patch-signals (swap! *state update :counter #(+ % 10))]]})
 ```
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps  {com.github.ben-manes.caffeine/caffeine {:mvn/version "3.2.2"}}
  :aliases
  {:dev {:extra-paths ["dev/src"]
-        :extra-deps  {com.github.brianium/datastar.wow {:mvn/version "1.0.0-RC1-wow0"}
+        :extra-deps  {com.github.brianium/datastar.wow {:mvn/version "1.0.0-RC1-wow2"}
                       dev.data-star.clojure/http-kit   {:mvn/version "1.0.0-RC1"}
                       integrant/integrant              {:mvn/version "0.13.1"}
                       io.github.tonsky/clj-reload      {:mvn/version "0.9.7"}
@@ -19,7 +19,7 @@
           slipset/deps-deploy {:mvn/version "0.2.2"}}
          :ns-default slim.lib
          :exec-args {:lib         com.github.brianium/datastar.wow.deacon
-                     :version     "1.2.0"
+                     :version     "1.3.0"
                      :url         "https://github.com/brianium/datastar.wow.deacon"
                      :description "Adds declarative connection management to datastar.wow applications"
                      :developer   "Brian Scaturro"}}}}

--- a/test/datastar/wow/deacon_test.clj
+++ b/test/datastar/wow/deacon_test.clj
@@ -83,10 +83,12 @@
           :datastar.wow/with-open-sse? with-open-sse?}
          n (update-nexus
             {:nexus/effects
-             {:datastar.wow/sse-closed (constantly ::closed)
+             {:datastar.wow/connection identity
+              :datastar.wow/sse-closed (constantly ::closed)
               :datastar.wow/send (constantly ::send)}})]
      (fn [& [sse-override]]
-       (nexus/dispatch n {:sse (or sse-override sse) :request request} dispatch-data fx)))))
+       (let [all-fx (into [[:datastar.wow/connection]] fx)]
+         (nexus/dispatch n {:sse (or sse-override sse) :request request} dispatch-data all-fx))))))
 
 (deftest dispatch-with-connection-interceptor
   (let [store (d*conn/store {:type :atom :atom *conns})]


### PR DESCRIPTION
Removes the use of `:datastar.wow/connection` for reading connections. I originally thought the api would be more consistent that way, but I have changed my mind.

The interceptor now makes use of the `:datastar.wow/connection` effect to inject a stored connection when available. This allows apps using deacon to just use `:datastar.wow.deacon/key` on datastar.wow responses.

The `:datastar.wow/connection` key will now effectively disable deacon (as datastar.wow gives priority to an explicitly provided connection).