### PR TITLE
feat: can list keys on connection store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [1.5.0] - 2025-09-19
 
+### Breaking changes
+
+deacon is using the new [registry](https://github.com/brianium/datastar.wow?tab=readme-ov-file#extending) pattern for datastar.wow. `update-nexus` is dropped in favor of a single `registry` function.
+
+datastar.wow.deacon now requires datastar.wow 1.0.0-RC3.wow1 or newer
+
 `ConnectionStore` protocol adds `list-keys` function.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.5.0] - 2025-09-19
+
+`ConnectionStore` protocol adds `list-keys` function.
+
+### Added
+
+Can now call `(d*conn/list-keys store)` to get a list of keys in the store.
+
 ## [1.4.0] - 2025-09-18
 
 Interceptor has fixed some issues and been made more performant. Connection closing and resolution is much more reliable with a single :before-dispatch interceptor.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ a period of inactivity.
 ;;; A caffeine backed store can be created with a :cache key overriding all other settings
 (d*conn/store {:type :caffeine
                :cache (create-a-caffeine-cache-somehow)})
+			   
+;;; Working with stores 
+
+(def store (d*conn/store {:type :atom)))
+
+;;; Look up a connection by key
+(d*conn/connection store :my-key)
+
+;;; List all keys in store
+(d*conn/list-keys store)
 ```
 
 ### Installing the nexus interceptor

--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,8 @@
  :deps  {com.github.ben-manes.caffeine/caffeine {:mvn/version "3.2.2"}}
  :aliases
  {:dev {:extra-paths ["dev/src"]
-        :extra-deps  {com.github.brianium/datastar.wow {:mvn/version "1.0.0-RC1-wow2"}
-                      dev.data-star.clojure/http-kit   {:mvn/version "1.0.0-RC1"}
+        :extra-deps  {com.github.brianium/datastar.wow {:mvn/version "1.0.0-RC3-wow1"}
+                      dev.data-star.clojure/http-kit   {:mvn/version "1.0.0-RC3"}
                       integrant/integrant              {:mvn/version "0.13.1"}
                       io.github.tonsky/clj-reload      {:mvn/version "0.9.7"}
                       metosin/malli                    {:mvn/version "0.19.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
           slipset/deps-deploy {:mvn/version "0.2.2"}}
          :ns-default slim.lib
          :exec-args {:lib         com.github.brianium/datastar.wow.deacon
-                     :version     "1.4.0"
+                     :version     "1.5.0"
                      :url         "https://github.com/brianium/datastar.wow.deacon"
                      :description "Adds declarative connection management to datastar.wow applications"
                      :developer   "Brian Scaturro"}}}}

--- a/dev/src/demo/app.clj
+++ b/dev/src/demo/app.clj
@@ -68,17 +68,10 @@
            (println "! Sent on closed channel"))))
      ctx)})
 
-(defn update-nexus
-  "Adds some application specific effects to demonstrate reusing connections.
-
-   Effects:
-
-   - ::subscribe - adds a watch to the atom to update signals. currently only supports a start then refresh scenario or start then open new tab scenario
-   - ::start-timer - increments state every second and dispatches the changes"
-  [n]
-  (-> (update n :nexus/effects merge effects)
-      (update :nexus/interceptors (fnil conj []) logger)
-      (update :nexus/placeholders merge placeholders)))
+(def registry
+  {::d*/effects effects
+   ::d*/interceptors [logger]
+   ::d*/placeholders placeholders})
 
 (defn with-datastar
   "datastar.wow/with-datastar component so we can tweak config in the demo app. If using
@@ -92,8 +85,7 @@
       :httpkit2 hk2/->sse-response)
     (-> deps
         (dissoc :type :store)
-        (assoc  :datastar.wow/update-nexus (comp (d*conn/update-nexus store) ;;; we can comp update-nexus functions - so here we are adding connection storage via deacon and some demo specific effects
-                                                 update-nexus)))))
+        (assoc  ::d*/registries [[d*conn/registry store] registry]))))
 
 (defn handler
   [{:keys [router middleware]}]

--- a/src/datastar/wow/deacon.clj
+++ b/src/datastar/wow/deacon.clj
@@ -39,6 +39,12 @@
   [s k]
   (impl/purge! s k))
 
+(defn list-keys
+  "Return a sequence of keys in the store. A key may be present even when a connection is
+   no longer available in storage - always check the result of (connection s k)"
+  [s]
+  (impl/list-keys s))
+
 (defn update-nexus
   "Returns an update-nexus function that can be used with datastar.wow. The following (optional lol) options
    are supported:

--- a/src/datastar/wow/deacon.clj
+++ b/src/datastar/wow/deacon.clj
@@ -2,7 +2,7 @@
   (:require [datastar.wow.deacon.protocols :as impl]
             [datastar.wow.deacon.atom :as deacon.atom]
             [datastar.wow.deacon.caffeine :as deacon.caff]
-            [datastar.wow.deacon.interceptors :as deacon.interceptors]))
+            [datastar.wow.deacon.registry :as deacon.registry]))
 
 (defmulti store
   "Create a connection store via an options map containing a :type key.
@@ -45,8 +45,8 @@
   [s]
   (impl/list-keys s))
 
-(defn update-nexus
-  "Returns an update-nexus function that can be used with datastar.wow. The following (optional lol) options
+(defn registry
+  "A registry function for datastar.wow. The following (optional lol) options
    are supported:
 
   | key         | description                                                                                                                 |
@@ -54,8 +54,8 @@
   | `:id-fn`    | Function that receives context and returns a unique per-user id. A typical case might be returning a user id from session.  |
   | `:on-purge` | Function that receives context and is called when a :datastar.wow/sse-closed effect is dispatched. Performs additional fx.  |"
   ([]
-   (deacon.interceptors/update-nexus))
+   (registry (store {:type :atom})))
   ([store]
-   (deacon.interceptors/update-nexus store))
+   (registry store {}))
   ([store opts]
-   (deacon.interceptors/update-nexus store opts)))
+   (deacon.registry/registry store opts)))

--- a/src/datastar/wow/deacon/atom.clj
+++ b/src/datastar/wow/deacon/atom.clj
@@ -9,7 +9,9 @@
   (connection [_ k]
     (@*atom k))
   (purge! [_ k]
-    (swap! *atom dissoc k)))
+    (swap! *atom dissoc k))
+  (list-keys [_]
+    (keys @*atom)))
 
 (defn store
   ([]

--- a/src/datastar/wow/deacon/caffeine.clj
+++ b/src/datastar/wow/deacon/caffeine.clj
@@ -9,6 +9,8 @@
   (store!   [_ k conn] (.put cache k conn))
   (connection [_ k]    (.getIfPresent cache k))
   (purge!   [_ k]      (.invalidate cache k))
+  (list-keys [_]       (-> (.asMap cache)
+                           (keys)))
 
   Object
   (toString [_]

--- a/src/datastar/wow/deacon/protocols.clj
+++ b/src/datastar/wow/deacon/protocols.clj
@@ -3,7 +3,8 @@
 (defprotocol ConnectionStore
   (store! [_ k sse-gen] "store an sse connection identified by key")
   (connection [_ k] "retrieve the connection identified by k if exists, otherwise nil")
-  (purge! [_ k] "remove the connection identified by k if it exists"))
+  (purge! [_ k] "remove the connection identified by k if it exists")
+  (list-keys [_] "return a sequence of keys contained in the store"))
 
 (defn store?
   [x]

--- a/src/datastar/wow/deacon/registry.clj
+++ b/src/datastar/wow/deacon/registry.clj
@@ -1,4 +1,4 @@
-(ns datastar.wow.deacon.interceptors
+(ns datastar.wow.deacon.registry
   (:require [datastar.wow.deacon.atom :as deacon.atom]
             [datastar.wow.deacon.protocols :as impl]))
 
@@ -31,40 +31,32 @@
   (impl/purge! store k)
   (update ctx :dispatch-data dissoc :datastar.wow/connection))
 
-(defn create-interceptor
+(defn registry
   "An interceptor that allows opt-in/managed connection persistence and reuse by adding
    a :datastar.wow.deacon/key value to a datastar.wow response."
   [store {:keys [id-fn on-purge]
           :or   {id-fn    (constantly :datastar.wow.deacon/id)
                  on-purge (constantly nil)}}]
   (assert (impl/store? store) "Interceptor store must satisfy ConnectionStore protocol")
-  {:id :datastar.wow.deacon/connections
+  {:datastar.wow/interceptors
+   [{:id :datastar.wow.deacon/connections
 
-   :before-dispatch
-   (fn [{:keys [actions]
-         {:keys [sse]} :system
-         {:datastar.wow/keys [connection]
-          {:datastar.wow/keys [with-open-sse?]} :datastar.wow/response} :dispatch-data
-         :as ctx}]
-     (if-some [k (scoped-key ctx id-fn)]
-       (let [action-ids (->> actions (map first) set)
-             conn?      (action-ids :datastar.wow/connection)
-             purge?     (action-ids :datastar.wow/sse-closed)
-             store?     (and (some? sse)
-                             (nil? connection)
-                             (not with-open-sse?))]
-         (cond
-           conn?    (with-connection ctx store k)
-           purge?   (purge! ctx store k on-purge)
-           store?   (store! ctx store k sse)
-           :else    ctx))
-       ctx))})
-
-(defn update-nexus
-  ([]
-   (update-nexus (deacon.atom/store)))
-  ([store]
-   (update-nexus store {}))
-  ([store opts]
-   (fn [nexus]
-     (update nexus :nexus/interceptors (fnil conj []) (create-interceptor store opts)))))
+     :before-dispatch
+     (fn [{:keys [actions]
+           {:keys [sse]} :system
+           {:datastar.wow/keys [connection]
+            {:datastar.wow/keys [with-open-sse?]} :datastar.wow/response} :dispatch-data
+           :as ctx}]
+       (if-some [k (scoped-key ctx id-fn)]
+         (let [action-ids (->> actions (map first) set)
+               conn?      (action-ids :datastar.wow/connection)
+               purge?     (action-ids :datastar.wow/sse-closed)
+               store?     (and (some? sse)
+                               (nil? connection)
+                               (not with-open-sse?))]
+           (cond
+             conn?    (with-connection ctx store k)
+             purge?   (purge! ctx store k on-purge)
+             store?   (store! ctx store k sse)
+             :else    ctx))
+         ctx))}]})

--- a/test/datastar/wow/deacon_test.clj
+++ b/test/datastar/wow/deacon_test.clj
@@ -17,7 +17,8 @@
     (testing "storing a connection"
       (let [conn (d*conn/store! s :test ::conn)]
         (is (and (= conn ::conn)
-                 (= conn (@*conns :test))))))
+                 (= conn (@*conns :test))
+                 (= (d*conn/list-keys s) (list :test))))))
     (testing "getting stored connections"
       (are [stored fetched] (= stored fetched)
         (d*conn/store! s :test ::conn) (d*conn/connection s :test)
@@ -31,7 +32,8 @@
   (let [s (d*conn/store {:type :caffeine})]
     (testing "storing a connection"
       (let [conn (d*conn/store! s :test ::conn)]
-        (is (= conn ::conn))))
+        (is (and (= conn ::conn)
+                 (= (d*conn/list-keys s) (list :test))))))
     (testing "getting stored connections"
       (are [stored fetched] (= stored fetched)
         (d*conn/store! s :test ::conn) (d*conn/connection s :test)


### PR DESCRIPTION
Added the ability to list keys in a store. This should be handy for looking up connections that follow a certain pattern

Adds a breaking change requiring an upgrade to datastar.wow 1.0.0-RC3-wow1