### PR TITLE
Add store? function to deacon namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .clj-kondo/
 .cpcache/
 .lsp/
+target/
 .nrepl-port

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+## Overview
+- Clojure library for datastar.wow connection stores and registry helpers.
+- Primary namespaces live under `src/datastar/wow/deacon`.
+
+## Common Commands
+- Run tests: `clojure -M:test:dev`
+
+## Notes
+- Use `datastar.wow.deacon/store?` to validate ConnectionStore implementations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.7.0] - 2026-01-07
+
+### Added
+
+`datastar.wow.deacon/store?` helper for checking if a value satisfies `ConnectionStore`.
+
 ## [1.6.0] - 2025-12-29
 
 ### Breaking changes

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
           slipset/deps-deploy {:mvn/version "0.2.2"}}
          :ns-default slim.lib
          :exec-args {:lib         com.github.brianium/datastar.wow.deacon
-                     :version     "1.6.0"
+                     :version     "1.7.0"
                      :url         "https://github.com/brianium/datastar.wow.deacon"
                      :description "Adds declarative connection management to datastar.wow applications"
                      :developer   "Brian Scaturro"}}}}

--- a/src/datastar/wow/deacon.clj
+++ b/src/datastar/wow/deacon.clj
@@ -28,6 +28,11 @@
   (impl/store! s k conn)
   conn)
 
+(defn store?
+  "Return true if `x` satisfies the ConnectionStore protocol."
+  [x]
+  (impl/store? x))
+
 (defn connection
   "Fetch the connection identifed by key `k` from storage. Returns
   nil if connection does not exist"

--- a/test/datastar/wow/deacon_test.clj
+++ b/test/datastar/wow/deacon_test.clj
@@ -28,6 +28,17 @@
       (d*conn/purge! s :purge)
       (is (nil? (d*conn/connection s :purge))))))
 
+(deftest store-predicate
+  (testing "recognizes valid stores"
+    (is (true? (d*conn/store? (d*conn/store {:type :atom :atom *conns}))))
+    (is (true? (d*conn/store? (d*conn/store {:type :caffeine})))))
+  (testing "rejects non-stores"
+    (are [x] (false? (d*conn/store? x))
+      nil
+      {}
+      []
+      ::not-a-store)))
+
 (deftest caffeine-store
   (let [s (d*conn/store {:type :caffeine})]
     (testing "storing a connection"


### PR DESCRIPTION
This pull request introduces a new helper predicate for validating connection stores in the `datastar.wow.deacon` namespace, updates documentation, and adds corresponding tests. The main focus is on making it easier to check if a value satisfies the `ConnectionStore` protocol.

**New helper function and documentation:**

* Added `store?` function to `src/datastar/wow/deacon.clj` for checking if a value satisfies the `ConnectionStore` protocol.
* Documented the new helper and usage instructions in `AGENTS.md`, including common commands and notes about validation.
* Updated `CHANGELOG.md` to reflect the addition of `datastar.wow.deacon/store?`.

**Testing improvements:**

* Added `store-predicate` test in `test/datastar/wow/deacon_test.clj` to ensure `store?` correctly identifies valid and invalid stores.